### PR TITLE
Input Option Value Empty Bugfix

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -22,8 +22,13 @@ async fn main() -> io::Result<()> {
             let input: &String = &args[2];
 
             if option == "i" {
-                let msg: &[u8] = input.as_bytes();
-                send_message_to_server(msg).await?;
+                if input == "" {
+                    eprintln!("Input is empty!");
+                }
+                else {
+                    let msg: &[u8] = input.as_bytes();
+                    send_message_to_server(msg).await?;
+                }
             }
             else {
                 eprintln!("Option does not exist!");


### PR DESCRIPTION
Ensure that the user can't send an empty message to the server when using the "i" option.